### PR TITLE
Add category search with datalist

### DIFF
--- a/API.md
+++ b/API.md
@@ -67,6 +67,27 @@ GET /health
 }
 ```
 
+## 🗂️ Branchen (Categories)
+
+### GET /api/categories
+
+Liefert alle verfügbaren Branchen. Optional kann mit dem Query-Parameter `search` nach einem Teilstring gefiltert werden.
+
+**Request:**
+```http
+GET /api/categories?search=kanal
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    { "id": 1, "name": "Kanalreinigung" }
+  ]
+}
+```
+
 ## 📅 Buchungen (Bookings)
 
 ### GET /api/bookings

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ koeln-branchen-portal/
 | `created_at` | Timestamp | Erstellungsdatum |
 | `updated_at` | Timestamp | Letzte Änderung |
 
+### Branchenverwaltung
+
+Alle zulässigen Branchen werden in einer separaten Tabelle `categories` gespeichert. Über den Endpoint `/api/categories` können sie abgefragt und durchsucht werden. Buchungen akzeptieren nur noch Branchen, die in dieser Tabelle vorhanden sind.
+
 ### Constraints und Validierung
 
 - **Zeitraum-Validierung**: `zeitraum_bis` muss nach `zeitraum_von` liegen

--- a/client/src/components/AvailabilityChecker.jsx
+++ b/client/src/components/AvailabilityChecker.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import useCategories from '../hooks/useCategories';
 
 const AvailabilityChecker = () => {
   const [formData, setFormData] = useState({
@@ -11,6 +12,7 @@ const AvailabilityChecker = () => {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState(null);
   const [error, setError] = useState('');
+  const categories = useCategories();
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -142,12 +144,18 @@ const AvailabilityChecker = () => {
               <input
                 type="text"
                 name="belegung"
+                list="availability-belegung-list"
                 value={formData.belegung}
                 onChange={handleInputChange}
-                placeholder="z.B. Gastronomie, Einzelhandel"
+                placeholder="z.B. Kanalreinigung"
                 className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
               />
+              <datalist id="availability-belegung-list">
+                {categories.map(cat => (
+                  <option key={cat.id} value={cat.name} />
+                ))}
+              </datalist>
             </div>
 
             <div>

--- a/client/src/components/BookingForm.jsx
+++ b/client/src/components/BookingForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import useCategories from '../hooks/useCategories';
 
 const BookingForm = ({ onBookingCreated }) => {
   const [formData, setFormData] = useState({
@@ -14,6 +15,7 @@ const BookingForm = ({ onBookingCreated }) => {
 
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState({ type: '', text: '' });
+  const categories = useCategories();
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -191,12 +193,18 @@ const BookingForm = ({ onBookingCreated }) => {
           <input
             type="text"
             name="belegung"
+            list="belegung-list"
             value={formData.belegung}
             onChange={handleInputChange}
-            placeholder="z.B. Gastronomie, Einzelhandel, Dienstleistung"
+            placeholder="z.B. Kanalreinigung"
             className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             required
           />
+          <datalist id="belegung-list">
+            {categories.map(cat => (
+              <option key={cat.id} value={cat.name} />
+            ))}
+          </datalist>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/client/src/components/BookingOverview.jsx
+++ b/client/src/components/BookingOverview.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react';
+import useCategories from '../hooks/useCategories';
 
 const BookingOverview = () => {
   const [bookings, setBookings] = useState([]);
   const [filteredBookings, setFilteredBookings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const categories = useCategories();
   
   const [filters, setFilters] = useState({
     search: '',
@@ -191,11 +193,17 @@ const BookingOverview = () => {
               </label>
               <input
                 type="text"
-                placeholder="z.B. Gastronomie"
+                list="filter-belegung-list"
+                placeholder="z.B. Kanalreinigung"
                 value={filters.belegung}
                 onChange={(e) => handleFilterChange('belegung', e.target.value)}
                 className="w-full p-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
+              <datalist id="filter-belegung-list">
+                {categories.map(cat => (
+                  <option key={cat.id} value={cat.name} />
+                ))}
+              </datalist>
             </div>
 
             <div>

--- a/client/src/hooks/useCategories.js
+++ b/client/src/hooks/useCategories.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+const useCategories = () => {
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/categories`);
+        const data = await res.json();
+        if (res.ok) {
+          setCategories(data.data || []);
+        }
+      } catch (err) {
+        console.error('Failed to load categories', err);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  return categories;
+};
+
+export default useCategories;

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ require('dotenv').config();
 const { testConnection, query } = require('./config/database');
 const bookingRoutes = require('./routes/bookings');
 const availabilityRoutes = require('./routes/availability');
+const categoryRoutes = require('./routes/categories');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -167,6 +168,7 @@ app.post('/api/admin/seed', async (req, res) => {
 // API routes
 app.use('/api/bookings', bookingRoutes);
 app.use('/api/availability', availabilityRoutes);
+app.use('/api/categories', categoryRoutes);
 
 // Error handling middleware
 app.use((err, req, res, next) => {

--- a/server/models/Booking.js
+++ b/server/models/Booking.js
@@ -1,5 +1,6 @@
 const { query, transaction } = require('../config/database');
 const Joi = require('joi');
+const Category = require('./Category');
 
 // Validation schema for booking data
 const bookingSchema = Joi.object({
@@ -88,6 +89,14 @@ class Booking {
   // Create a new booking
   static async create(bookingData) {
     const validatedData = this.validate(bookingData);
+
+    const categoryExists = await Category.exists(validatedData.belegung);
+    if (!categoryExists) {
+      const error = new Error('Invalid category');
+      error.name = 'ValidationError';
+      error.details = [{ field: 'belegung', message: 'Ungültige Branche' }];
+      throw error;
+    }
     
     // Check for conflicts
     const conflicts = await this.checkConflict(
@@ -189,6 +198,14 @@ class Booking {
     }
 
     const validatedData = this.validate({ ...existingBooking, ...updateData });
+
+    const categoryExists = await Category.exists(validatedData.belegung);
+    if (!categoryExists) {
+      const error = new Error('Invalid category');
+      error.name = 'ValidationError';
+      error.details = [{ field: 'belegung', message: 'Ungültige Branche' }];
+      throw error;
+    }
 
     // Check for conflicts (excluding current booking)
     const conflicts = await this.checkConflict(

--- a/server/models/Category.js
+++ b/server/models/Category.js
@@ -1,0 +1,23 @@
+const { query } = require('../config/database');
+
+class Category {
+  static async all() {
+    const result = await query('SELECT id, name FROM categories ORDER BY name');
+    return result.rows;
+  }
+
+  static async search(term) {
+    const result = await query(
+      'SELECT id, name FROM categories WHERE name ILIKE $1 ORDER BY name LIMIT 10',
+      [`%${term}%`]
+    );
+    return result.rows;
+  }
+
+  static async exists(name) {
+    const result = await query('SELECT 1 FROM categories WHERE name = $1', [name]);
+    return result.rowCount > 0;
+  }
+}
+
+module.exports = Category;

--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const Category = require('../models/Category');
+
+// GET /api/categories - list categories, optional search
+router.get('/', async (req, res, next) => {
+  try {
+    const { search } = req.query;
+    const categories = search ? await Category.search(search) : await Category.all();
+    res.json({ success: true, data: categories });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/server/scripts/migrate.js
+++ b/server/scripts/migrate.js
@@ -12,7 +12,16 @@ const createTables = async () => {
   
   try {
     console.log('🚀 Starting database migration...');
-    
+
+    // Create categories table
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS categories (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(100) NOT NULL UNIQUE
+      );
+    `);
+    console.log('✅ Created categories table');
+
     // Create bookings table
     await client.query(`
       CREATE TABLE IF NOT EXISTS bookings (

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -7,6 +7,18 @@ const pool = new Pool({
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });
 
+const sampleCategories = [
+  'Gastronomie',
+  'Einzelhandel',
+  'Dienstleistung',
+  'Handwerk',
+  'IT-Services',
+  'Beratung',
+  'Immobilien',
+  'Gesundheitswesen',
+  'Kanalreinigung'
+];
+
 const sampleBookings = [
   {
     kundenname: 'Max Mustermann',
@@ -115,14 +127,22 @@ const seedDatabase = async () => {
   
   try {
     console.log('🌱 Starting database seeding...');
-    
+
     // Clear existing data
     await client.query('DELETE FROM bookings');
-    console.log('🗑️  Cleared existing bookings');
+    await client.query('DELETE FROM categories');
+    console.log('🗑️  Cleared existing bookings and categories');
     
-    // Reset sequence
+    // Reset sequences
     await client.query('ALTER SEQUENCE bookings_id_seq RESTART WITH 1');
-    console.log('🔄 Reset ID sequence');
+    await client.query('ALTER SEQUENCE categories_id_seq RESTART WITH 1');
+    console.log('🔄 Reset ID sequences');
+
+    // Insert sample categories
+    for (const name of sampleCategories) {
+      await client.query('INSERT INTO categories (name) VALUES ($1)', [name]);
+    }
+    console.log(`✅ Inserted ${sampleCategories.length} categories`);
     
     // Insert sample bookings
     for (const booking of sampleBookings) {
@@ -203,9 +223,11 @@ const clearDatabase = async () => {
   
   try {
     console.log('🗑️  Clearing database...');
-    
+
     await client.query('DELETE FROM bookings');
+    await client.query('DELETE FROM categories');
     await client.query('ALTER SEQUENCE bookings_id_seq RESTART WITH 1');
+    await client.query('ALTER SEQUENCE categories_id_seq RESTART WITH 1');
     
     console.log('✅ Database cleared');
     


### PR DESCRIPTION
## Summary
- add `categories` table migration and seeding
- validate booking `belegung` using new categories
- expose `/api/categories` endpoint
- add hook to fetch categories
- use datalist autocomplete for categories in forms and filters
- document categories endpoint and DB changes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` in `client` *(fails: Cannot find module '@eslint/js')*
- `node test-api.js` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_b_68623dec82fc832c9e75ab4dea63e3e7